### PR TITLE
Fix nightly CI job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - run: git clone https://github.com/wagtail/wagtail.git
 
       - run: python -m pip install flit
-      - run: flit install --deps production --extras testing
+      - run: flit install --deps=production --extras=mailchimp,testing
       - run: python -m pip install ./wagtail
 
       - run: python testmanage.py test


### PR DESCRIPTION
This job failed last night because, in https://github.com/wagtail/wagtail-newsletter/pull/21/files, I forgot to add `mailchimp` to the `--extras` list in `nightly.yml`:

https://github.com/wagtail/wagtail-newsletter/actions/runs/9105242838/job/25030492062