### PR TITLE
Fix nightly test command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       - run: flit install --deps=production --extras=mailchimp,mrml,testing
       - run: python -m pip install ./wagtail
 
-      - run: python testmanage.py test
+      - run: pytest -vv
 
       - name: Report failure
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ pythonVersion = "3.8"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "wagtail_newsletter.test.settings"
+testpaths = [
+    "tests",
+]
 filterwarnings = [
     "ignore:The default scheme will be changed.*forms.URLField:django.utils.deprecation.RemovedAfterNextVersionWarning",
     "ignore:'index_together' is deprecated:django.utils.deprecation.RemovedAfterNextVersionWarning",


### PR DESCRIPTION
Another fix for the nightly CI:
- Run tests using `pytest`, like `tox.ini` does.
- Only search for tests under `tests/`, so we don't pick up Wagtail's testsuite.