### PR TITLE
Preview campaign

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ def clear_cache():
 
 
 class MemoryCampaignBackend(CampaignBackend):
+    name = "Testing"
+
     def __init__(self):
         self.audiences = []
         self.segments = {}
@@ -37,7 +39,7 @@ class MemoryCampaignBackend(CampaignBackend):
             raise Audience.DoesNotExist
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def memory_backend(monkeypatch: pytest.MonkeyPatch):
     backend = MemoryCampaignBackend()
     monkeypatch.setattr(

--- a/tests/test_campaign_view.py
+++ b/tests/test_campaign_view.py
@@ -1,0 +1,54 @@
+import pytest
+
+from django.test import Client
+from django.urls import resolve, reverse
+from wagtail.models import Site
+
+from tests.conftest import MemoryCampaignBackend
+from wagtail_newsletter.test.models import ArticlePage, CustomRecipients
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def page():
+    page = ArticlePage(title="Test Article")
+    Site.objects.get().root_page.add_child(instance=page)
+    return page
+
+
+@pytest.mark.parametrize(
+    "post_data,view_name",
+    [
+        ({}, "wagtailadmin_pages:edit"),
+        ({"newsletter_action": "preview_campaign"}, "wagtail_newsletter:campaign"),
+    ],
+)
+def test_save_revision_redirect(
+    page: ArticlePage, admin_client: Client, post_data, view_name
+):
+    url = reverse("wagtailadmin_pages:edit", kwargs={"page_id": page.pk})
+    data = {"title": page.title, "slug": page.slug, **post_data}
+    response = admin_client.post(url, data)
+    assert response.status_code == 302
+    response_url = response.url  # type: ignore
+    assert resolve(response_url).view_name == view_name
+
+
+def test_campaign_view_context(page: ArticlePage, admin_client: Client):
+    page.body = "Hello Test Campaign"
+    page.newsletter_recipients = CustomRecipients.objects.create()
+    url = reverse(
+        "wagtail_newsletter:campaign",
+        kwargs={"page_id": page.pk, "revision_id": page.save_revision().pk},
+    )
+    response = admin_client.get(url)
+    context = dict(response.context)
+    assert context["page"] == page
+    assert context["campaign_data"]["recipients"] == page.newsletter_recipients
+    assert context["campaign_data"]["subject"] == page.title
+    assert (
+        f'<h1 class="newsletter">{page.title}</h1>' in context["campaign_data"]["html"]
+    )
+    assert context["backend_name"] == MemoryCampaignBackend.name

--- a/wagtail_newsletter/campaign_backends/__init__.py
+++ b/wagtail_newsletter/campaign_backends/__init__.py
@@ -12,6 +12,8 @@ DEFAULT_CAMPAIGN_BACKEND = (
 
 
 class CampaignBackend(ABC):
+    name: str
+
     @abstractmethod
     def get_audiences(self) -> "list[audiences.Audience]": ...
 

--- a/wagtail_newsletter/campaign_backends/mailchimp.py
+++ b/wagtail_newsletter/campaign_backends/mailchimp.py
@@ -13,6 +13,8 @@ from . import CampaignBackend
 
 
 class MailchimpCampaignBackend(CampaignBackend):
+    name = "Mailchimp"
+
     def __init__(self):
         self.client = Client()
         self.client.set_config(self.get_client_config())

--- a/wagtail_newsletter/models.py
+++ b/wagtail_newsletter/models.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.models import Page
 
-from . import audiences, get_recipients_model_string
+from . import audiences, get_recipients_model_string, panels
 
 
 class NewsletterRecipientsBase(models.Model):
@@ -92,9 +92,11 @@ class NewsletterPageMixin(Page):
         return [
             FieldPanel(
                 "newsletter_recipients",
+                heading="Recipients",
                 widget=recipients_chooser_viewset.widget_class,
             ),
-            FieldPanel("newsletter_subject"),
+            FieldPanel("newsletter_subject", heading="Subject"),
+            panels.NewsletterPanel(heading="Campaign"),
         ]
 
     preview_modes = [  # type: ignore
@@ -123,8 +125,6 @@ class NewsletterPageMixin(Page):
     # revisions. In effect, these fields behave as if they were not versioned.
     # Subclasses may add their own newsletter-related fields to this list.
     newsletter_persistent_fields = [
-        "newsletter_recipients",
-        "newsletter_subject",
         "newsletter_campaign",
     ]
 

--- a/wagtail_newsletter/panels.py
+++ b/wagtail_newsletter/panels.py
@@ -1,0 +1,6 @@
+from wagtail.admin.panels import Panel
+
+
+class NewsletterPanel(Panel):
+    class BoundPanel(Panel.BoundPanel):
+        template_name = "wagtail_newsletter/panels/newsletter_panel.html"

--- a/wagtail_newsletter/static/wagtail_newsletter/css/wagtail_newsletter.css
+++ b/wagtail_newsletter/static/wagtail_newsletter/css/wagtail_newsletter.css
@@ -1,0 +1,19 @@
+.wn-campaign {
+  margin-inline-start: 5rem;
+  margin-inline-end: 5rem;
+
+  iframe#wn-body {
+    background-color: var(--w-color-surface-field);
+    border: 1px solid var(--w-color-border-field-default);
+    border-color: var(--w-color-border-field-hover);
+    border-radius: .3125rem;
+    color: var(--w-color-text-context);
+    font-size: 1.1875rem;
+    font-weight: 400;
+    line-height: 1.5;
+    min-height: 2.625rem;
+    padding: .375rem 1.25rem;
+    width: 100%;
+    height: 50vh;
+  }
+}

--- a/wagtail_newsletter/templates/wagtail_newsletter/campaign.html
+++ b/wagtail_newsletter/templates/wagtail_newsletter/campaign.html
@@ -1,0 +1,57 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load static %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/headers/page_edit_header.html" %}
+
+    <div class="wn-campaign">
+        <h1 class="w-h1">Save campaign</h1>
+
+        <h2>Recipients</h2>
+        <p>
+            {% if recipients %}
+                <em>{{ campaign_data.recipients.name }}</em> with
+                <strong>{{ campaign_data.recipients.member_count }} subscribers</strong>
+            {% else %}
+                <em>Not set</em>
+            {% endif %}
+        </p>
+
+        <h2>Subject</h2>
+        <p>{{ campaign_data.subject }}</p>
+
+        <h2>Body</h2>
+        <iframe id="wn-body"></iframe>
+
+        {{ campaign_data.html|json_script:"wn-html" }}
+
+        <script>
+            document.querySelector("#wn-body").srcdoc = JSON.parse(
+                document.querySelector("#wn-html").textContent
+            );
+        </script>
+
+        <form method="POST">
+            {% csrf_token %}
+
+            <a href="{{ next_url }}" class="button no">Cancel</a>
+
+            <button type="button" class="button button-secondary">
+                Save to {{ backend_name }}
+            </button>
+
+            <button type="button" class="button button-secondary">
+                Send test email
+            </button>
+
+            <button type="button" class="button">
+                Send campaign
+            </button>
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "wagtail_newsletter/css/wagtail_newsletter.css" %}">
+{% endblock %}

--- a/wagtail_newsletter/templates/wagtail_newsletter/panels/newsletter_panel.html
+++ b/wagtail_newsletter/templates/wagtail_newsletter/panels/newsletter_panel.html
@@ -1,0 +1,19 @@
+{% load wagtailadmin_tags %}
+
+<div class="wn-panel">
+    <div class="help-block help-info">
+        {% icon name="help" %}
+        This action will save a new page revision.
+    </div>
+
+    <p>
+        <button
+            type="submit"
+            class="button"
+            name="newsletter_action"
+            value="preview_campaign"
+        >
+            Save campaign
+        </button>
+    </p>
+</div>

--- a/wagtail_newsletter/views.py
+++ b/wagtail_newsletter/views.py
@@ -1,0 +1,53 @@
+from typing import cast
+
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.views.generic import View
+from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+from wagtail.models import ContentType, Page, Revision
+
+from . import campaign_backends
+from .models import NewsletterPageMixin
+
+
+class CampaignView(WagtailAdminTemplateMixin, View):
+    template_name = "wagtail_newsletter/campaign.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        edit_url = reverse(
+            "wagtailadmin_pages:edit", kwargs={"page_id": self.object.pk}
+        )
+        context.update(
+            page=self.object,
+            campaign_data=self.campaign_data,
+            backend_name=self.backend.name,
+            next_url=f"{edit_url}#tab-newsletter",
+        )
+        return context
+
+    def dispatch(self, request: HttpRequest, *, page_id: int, revision_id: int):  # type: ignore
+        self.object = cast(
+            NewsletterPageMixin, get_object_or_404(Page, pk=page_id).specific
+        )
+        self.revision = cast(
+            NewsletterPageMixin,
+            get_object_or_404(
+                Revision,
+                base_content_type=ContentType.objects.get_for_model(Page),
+                pk=revision_id,
+            ).as_object(),
+        )
+        self.campaign_data = {
+            "recipients": self.revision.newsletter_recipients,
+            "subject": self.revision.newsletter_subject or self.revision.title,
+            "html": self.revision.get_newsletter_html(),
+        }
+
+        self.backend = campaign_backends.get_backend()
+
+        return super().dispatch(request)
+
+    def get(self, request):
+        return self.render_to_response(self.get_context_data())


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail-newsletter/issues/31

After some back and forth, we've changed how campaign data is saved: we require the user to save a revision, and base the campaign off of that revision's content. This way it's unambiguous what the campaign content will be; there's no room for the user to forget to save their changes on the Wagtail Page and/or have another user overwrite their work before the campaign is saved.

Therefore, I've changed the behaviour of the `newsletter_recipients` and `newsletter_subject` fields: they are no longer specially persisted regardless of revisions; they are now part of the regular revision content. The `newsletter_campaign` field is still persisted: it's not editable by the user, and it's not helpful to have it overwritten when restoring a previous revision.