### PR TITLE
Improve test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,5 +20,6 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    @abstract
 
 ignore_errors = True

--- a/tests/test_mrml.py
+++ b/tests/test_mrml.py
@@ -1,6 +1,6 @@
 import pytest
 
-from django.template import Context, Template
+from django.template import Context, Template, TemplateSyntaxError
 from django.utils.safestring import mark_safe
 
 from wagtail_newsletter.templatetags.wagtail_newsletter import MRMLError
@@ -24,6 +24,18 @@ def test_render_mjml():
     assert message in html
     # Since this was rendered for email, it should have some weird markup inside.
     assert "<o:OfficeDocumentSettings>" in html
+
+
+def test_mrml_tag_receives_no_arguments():
+    with pytest.raises(TemplateSyntaxError) as error:
+        Template(
+            """
+            {% load wagtail_newsletter %}
+            {% mrml unexpected_argument %}{% endmrml %}
+            """
+        )
+
+    assert error.match("'mrml' tag doesn't receive any arguments.")
 
 
 def test_render_mjml_syntax_error():

--- a/tests/test_page_mixin_model.py
+++ b/tests/test_page_mixin_model.py
@@ -95,6 +95,13 @@ def test_newsletter_html_get_template():
     assert page.get_newsletter_template.call_count == 1
 
 
+def test_preview_default():
+    page = ArticlePage(title="Page title")
+    request = RequestFactory().get("/")
+    response = page.serve_preview(request, "default").render()  # type: ignore
+    assert '<h1 class="web">Page title</h1>' in response.content.decode()
+
+
 def test_preview_newsletter():
     page = ArticlePage(title="Page title")
     request = RequestFactory().get("/")

--- a/tests/test_page_mixin_model.py
+++ b/tests/test_page_mixin_model.py
@@ -99,7 +99,7 @@ def test_preview_default():
     page = ArticlePage(title="Page title")
     request = RequestFactory().get("/")
     response = page.serve_preview(request, "default").render()  # type: ignore
-    assert '<h1 class="web">Page title</h1>' in response.content.decode()
+    assert b'<h1 class="web">Page title</h1>' in response.content
 
 
 def test_preview_newsletter():

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -20,10 +20,28 @@ BACKEND_ERROR_TEXT = "something failed"
 
 
 @pytest.mark.django_db
-def test_panels(admin_client: Client):
-    page = ArticlePage(title="title 0")
-    Site.objects.get().root_page.add_child(instance=page)
-    url = reverse("wagtailadmin_pages:edit", kwargs={"page_id": page.pk})
+@pytest.mark.parametrize(
+    "page_exists",
+    [True, False],
+)
+def test_panels(admin_client: Client, page_exists):
+    home_page = Site.objects.get().root_page
+
+    if page_exists:
+        page = ArticlePage(title="title 0")
+        home_page.add_child(instance=page)
+        url = reverse("wagtailadmin_pages:edit", kwargs={"page_id": page.pk})
+
+    else:
+        url = reverse(
+            "wagtailadmin_pages:add",
+            kwargs={
+                "content_type_app_name": "wagtail_newsletter_test",
+                "content_type_model_name": "articlepage",
+                "parent_page_id": home_page.pk,
+            },
+        )
+
     response = admin_client.get(url)
     panels = {
         tab.heading: [panel.heading for panel in tab.children]

--- a/tests/test_recipients_model.py
+++ b/tests/test_recipients_model.py
@@ -64,3 +64,9 @@ def test_segment_validation(
             recipients.full_clean()
 
         assert error.match(r"The segment is not part of the selected audience.")
+
+
+def test_str():
+    NAME = "test"
+    recipients = NewsletterRecipients(name=NAME)
+    assert str(recipients) == NAME

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -20,3 +20,50 @@ def test_richtext_expands_page_link():
     html = template.render(Context({"value": value}))
 
     assert html.strip() == '<a href="http://localhost/page/">link</a>'
+
+
+@pytest.mark.django_db
+def test_richtext_handles_broken_page_link():
+    page = Page(title="Page")
+    Site.objects.get().root_page.add_child(instance=page)
+
+    template = Template(
+        """
+        {% load wagtail_newsletter %}
+        {{ value|newsletter_richtext }}
+        """
+    )
+    value = RichText('<a linktype="page" id="999999">link</a>')
+    html = template.render(Context({"value": value}))
+
+    assert html.strip() == "<a>link</a>"
+
+
+@pytest.mark.django_db
+def test_string_is_wrapped_as_rich_text():
+    page = Page(title="Page")
+    Site.objects.get().root_page.add_child(instance=page)
+
+    template = Template(
+        """
+        {% load wagtail_newsletter %}
+        {{ value|newsletter_richtext }}
+        """
+    )
+    value = f'<a linktype="page" id="{page.pk}">link</a>'
+    html = template.render(Context({"value": value}))
+
+    assert html.strip() == '<a href="http://localhost/page/">link</a>'
+
+
+def test_richtext_not_a_string():
+    template = Template(
+        """
+        {% load wagtail_newsletter %}
+        {{ value|newsletter_richtext }}
+        """
+    )
+    with pytest.raises(ValueError) as error:
+        template.render(Context({"value": 13}))
+
+    assert error.match("Expected string value")

--- a/wagtail_newsletter/models.py
+++ b/wagtail_newsletter/models.py
@@ -105,7 +105,7 @@ class NewsletterPageMixin(Page):
     ]
 
     @classmethod
-    def get_edit_handler(cls):
+    def get_edit_handler(cls):  # pragma: no cover
         tabs = []
 
         if cls.content_panels:

--- a/wagtail_newsletter/test/templates/wagtail_newsletter_test/article_page.html
+++ b/wagtail_newsletter/test/templates/wagtail_newsletter_test/article_page.html
@@ -1,0 +1,1 @@
+<h1 class="web">{{ page.title }}</h1>

--- a/wagtail_newsletter/wagtail_hooks.py
+++ b/wagtail_newsletter/wagtail_hooks.py
@@ -37,7 +37,7 @@ def register_admin_viewset():
         viewsets.audience_segment_chooser_viewset,
         viewsets.recipients_chooser_viewset,
     ]
-    if get_recipients_model_string() == DEFAULT_RECIPIENTS_MODEL:
+    if get_recipients_model_string() == DEFAULT_RECIPIENTS_MODEL:  # pragma: no cover
         register_viewsets.append(viewsets.newsletter_recipients_viewset)
     return register_viewsets
 
@@ -47,8 +47,10 @@ def register_admin_viewset():
 def redirect_to_campaign_page(request, page: Page):
     newsletter_action = request.POST.get("newsletter_action")
 
-    if newsletter_action is not None:
-        page = cast(NewsletterPageMixin, page)
+    if newsletter_action is None:  # pragma: no cover
+        return
 
-        if newsletter_action == "save_campaign":
-            actions.save_campaign(request, page)
+    page = cast(NewsletterPageMixin, page)
+
+    if newsletter_action == "save_campaign":
+        actions.save_campaign(request, page)


### PR DESCRIPTION
Bring test coverage to almost 100% ([before](https://github.com/wagtail/wagtail-newsletter/actions/runs/9496023726/job/26169561260#step:6:644); [after](https://github.com/wagtail/wagtail-newsletter/actions/runs/9496355551/job/26170600191?pr=35#step:6:695); one `if` branch is still seen as not-covered but implementing https://github.com/wagtail/wagtail-newsletter/issues/17 will cover that too). This makes it easier to spot new code that's not covered in tests.