### PR TITLE
Add Django Debug Toolbar to the demo app

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -16,6 +16,10 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["localhost"]
 
+INTERNAL_IPS = [
+    "127.0.0.1",
+]
+
 INSTALLED_APPS = [
     "wagtail_newsletter",
     "demo",
@@ -36,6 +40,7 @@ INSTALLED_APPS = [
     "wagtail",
     "taggit",
     "rest_framework",
+    "debug_toolbar",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -46,6 +51,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -15,4 +15,8 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns = [
+        path("__debug__/", include("debug_toolbar.urls")),
+        *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
+        *urlpatterns,
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
     "dj-database-url==2.1.0",
+    "django-debug-toolbar==4.4.2",
     "django-stubs==4.2.7",
     "pre-commit==3.4.0",
     "pyright==1.1.360",


### PR DESCRIPTION
As the demo app is used for development, this might come in handy.