### PR TITLE
Move the real submit buttons to inside the dialogs

### DIFF
--- a/wagtail_newsletter/panels.py
+++ b/wagtail_newsletter/panels.py
@@ -18,9 +18,8 @@ class NewsletterPanel(Panel):
         instance: "models.NewsletterPageMixin"
 
         class Media:
-            js = [
-                "wagtail_newsletter/js/wagtail_newsletter.js",
-            ]
+            css = {"all": ["wagtail_newsletter/css/wagtail_newsletter.css"]}
+            js = ["wagtail_newsletter/js/wagtail_newsletter.js"]
 
         @cached_property
         def permissions(self):
@@ -72,6 +71,7 @@ class NewsletterPanel(Panel):
             context["campaign"] = campaign
             context["test_form"] = forms.SendTestEmailForm(
                 initial={"email": self.request.user.email},
+                prefix="newsletter-test",
             )
 
             if campaign is not None and campaign.sent:

--- a/wagtail_newsletter/static/wagtail_newsletter/css/wagtail_newsletter.css
+++ b/wagtail_newsletter/static/wagtail_newsletter/css/wagtail_newsletter.css
@@ -1,0 +1,10 @@
+.wn-panel--buttons {
+  display: flex;
+  flex-flow: row wrap;
+  row-gap: 0.5rem;
+  column-gap: 1rem;
+
+  .button {
+    margin-inline-start: 0;
+  }
+}

--- a/wagtail_newsletter/static/wagtail_newsletter/js/wagtail_newsletter.js
+++ b/wagtail_newsletter/static/wagtail_newsletter/js/wagtail_newsletter.js
@@ -1,21 +1,11 @@
 window.wagtail.app.register("wn-panel",
   class extends window.StimulusModule.Controller {
     static targets = [
-      "testButton",
-      "testAddress",
-      "testSubmit",
       "sendButton",
-      "sendSubmit",
     ]
 
     static values = {
       recipientsUrl: String
-    }
-
-    get testButtonProgress() {
-      return this.application.getControllerForElementAndIdentifier(
-        this.testButtonTarget, "w-progress"
-      );
     }
 
     get sendButtonProgress() {
@@ -28,12 +18,6 @@ window.wagtail.app.register("wn-panel",
       return this.application.getControllerForElementAndIdentifier(
         document.querySelector("#wn-recipients-required"), "w-dialog"
       );
-    }
-
-    test(event) {
-      this.testAddressTarget.value = event.detail.address;
-      this.testButtonProgress.activate();
-      this.testSubmitTarget.click();
     }
 
     async clickSend() {
@@ -65,28 +49,6 @@ window.wagtail.app.register("wn-panel",
         this.sendButtonProgress.loadingValue = false;
       }
     }
-
-    send() {
-      this.sendButtonProgress.activate();
-      this.sendSubmitTarget.click();
-    }
-  }
-);
-
-
-window.wagtail.app.register("wn-test",
-  class extends window.StimulusModule.Controller {
-    get dialog() {
-      return this.application.getControllerForElementAndIdentifier(
-        this.element.closest("[data-controller=w-dialog]"), "w-dialog"
-      );
-    }
-
-    submit() {
-      const address = this.element.querySelector("input[name=email]").value;
-      this.dispatch("submit", { detail: { address } });
-      this.dialog.hide();
-    }
   }
 );
 
@@ -108,10 +70,15 @@ window.wagtail.app.register("wn-send",
       this.messageTarget.textContent = `Sending campaign to ${name}, with ${member_count} recipients.`;
       this.dialog.show();
     }
+  }
+);
 
-    submit() {
-      this.dispatch("submit");
-      this.dialog.hide();
+
+window.wagtail.app.register("wn-submit",
+  class extends window.StimulusModule.Controller {
+    sendEvent(event) {
+      const eventName = this.element.value;
+      this.dispatch(eventName, { detail: { event } });
     }
   }
 );

--- a/wagtail_newsletter/templates/wagtail_newsletter/panels/newsletter_panel.html
+++ b/wagtail_newsletter/templates/wagtail_newsletter/panels/newsletter_panel.html
@@ -4,10 +4,6 @@
     class="wn-panel"
     data-controller="wn-panel"
     data-wn-panel-recipients-url-value="{% url "wagtail_newsletter:recipients" %}"
-    data-action="
-        wn-test:submit@window->wn-panel#test
-        wn-send:submit@window->wn-panel#send
-    "
 >
     {% if error_message %}
         <div class="help-block help-critical">
@@ -51,118 +47,162 @@
 
     {% else %}
 
-        {% if has_action_permission %}
-            <div class="help-block help-info">
-                {% icon name="help" %}
-                These actions will save a new page revision.
-            </div>
-        {% endif %}
-
         <p>
-            <input
-                type="hidden"
-                name="newsletter-test-email"
-                data-wn-panel-target="testAddress"
-            >
+            <div class="wn-panel--buttons">
+                {% if has_action_permission.save_campaign %}
+                    <button
+                        type="button"
+                        class="button button-secondary button-longrunning"
+                        data-a11y-dialog-show="wn-save-dialog"
+                        data-controller="w-progress"
+                        data-action="wn-submit:save_campaign@window->w-progress#activate"
+                    >
+                        {% icon name="spinner" %}
+                        Save campaign to {{ backend_name }}
+                    </button>
+                {% endif %}
 
-            {% if has_action_permission.save_campaign %}
+                {% if has_action_permission.send_test_email %}
+                    <button
+                        type="button"
+                        class="button button-secondary button-longrunning"
+                        data-a11y-dialog-show="wn-test-dialog"
+                        data-controller="w-progress"
+                        data-action="wn-submit:send_test_email@window->w-progress#activate"
+                    >
+                        {% icon name="spinner" %}
+                        Send test email
+                    </button>
+                {% endif %}
+
+                {% if has_action_permission.send_campaign %}
+                    <button
+                        type="button"
+                        class="button button-primary button-longrunning"
+                        data-controller="w-progress"
+                        data-wn-panel-target="sendButton"
+                        data-action="
+                            wn-panel#clickSend
+                            wn-submit:send_campaign@window->w-progress#activate
+                        "
+                    >
+                        {% icon name="spinner" %}
+                        Send campaign
+                    </button>
+                {% endif %}
+            </div>
+
+            {% dialog icon_name="mail" id="wn-save-dialog" title="Save campaign" dialog_root_selector="[data-edit-form]" %}
+                <p class="w-dialog__subtitle w-help-text">
+                    This action will save a draft page revision.
+                </p>
+
                 <button
                     type="submit"
-                    class="button button-secondary button-longrunning"
+                    class="button button-primary"
                     name="newsletter-action"
                     value="save_campaign"
-                    data-controller="w-progress"
-                    data-action="w-progress#activate"
+                    data-controller="wn-submit"
+                    data-action="
+                        wn-submit#sendEvent
+                        w-dialog#hide
+                    "
                 >
-                    {% icon name="spinner" %}
                     Save campaign to {{ backend_name }}
                 </button>
-            {% endif %}
 
-            {% if has_action_permission.send_test_email %}
                 <button
                     type="button"
-                    class="button button-secondary button-longrunning"
-                    data-a11y-dialog-show="wn-test-dialog"
-                    data-controller="w-progress"
-                    data-wn-panel-target="testButton"
+                    class="button button-secondary"
+                    data-action="w-dialog#hide"
                 >
-                    {% icon name="spinner" %}
-                    Send test email
+                    Cancel
                 </button>
-            {% endif %}
-
-            {% if has_action_permission.send_campaign %}
-                <button
-                    type="button"
-                    class="button button-primary button-longrunning"
-                    data-controller="w-progress"
-                    data-wn-panel-target="sendButton"
-                    data-action="wn-panel#clickSend"
-                >
-                    {% icon name="spinner" %}
-                    Send campaign
-                </button>
-            {% endif %}
-
-            {% dialog icon_name="mail" id="wn-test-dialog" title="Send test email" %}
-                <form
-                    data-controller="wn-test"
-                    data-action="wn-test#submit:prevent"
-                >
-                    {% include "wagtailadmin/shared/field.html" with field=test_form.email %}
-
-                    <button type="submit" class="button button-primary">Send</button>
-                    <button type="button" class="button button-secondary" data-action="w-dialog#hide">Cancel</button>
-                </form>
             {% enddialog %}
 
-            {% dialog icon_name="mail" id="wn-recipients-required" title="Send campaign" %}
+            {% dialog icon_name="mail" id="wn-test-dialog" title="Send test email" dialog_root_selector="[data-edit-form]" %}
+                <p class="w-dialog__subtitle w-help-text">
+                    This action will save a draft page revision.
+                </p>
+
+                {% include "wagtailadmin/shared/field.html" with field=test_form.email %}
+
+                <button
+                    type="submit"
+                    class="button button-primary"
+                    name="newsletter-action"
+                    value="send_test_email"
+                    data-controller="wn-submit"
+                    data-action="
+                        wn-submit#sendEvent
+                        w-dialog#hide
+                    "
+                >
+                    Send test email
+                </button>
+
+                <button
+                    type="button"
+                    class="button button-secondary"
+                    data-action="w-dialog#hide"
+                >
+                    Cancel
+                </button>
+            {% enddialog %}
+
+            {% dialog icon_name="mail" id="wn-recipients-required" title="Send campaign" dialog_root_selector="[data-edit-form]" %}
                 <div class="help-block help-warning">
                     {% icon name="warning" %}
                     <p>You must frist select recipients for the newsletter.</p>
                 </div>
-                <button type="button" class="button" data-action="w-dialog#hide">Continue</button>
+
+                <button
+                    type="button"
+                    class="button"
+                    data-action="w-dialog#hide"
+                >
+                    Continue
+                </button>
             {% enddialog %}
 
-            {% dialog icon_name="mail" id="wn-send-dialog" title="Send campaign" %}
-                <form
+            {% dialog icon_name="mail" id="wn-send-dialog" title="Send campaign" dialog_root_selector="[data-edit-form]" %}
+                <div
                     class="loading-mask"
                     data-controller="wn-send"
-                    data-action="
-                        wn-send#submit:prevent
-                        wn-panel:showSendDialog@window->wn-send#show
-                    "
+                    data-action="wn-panel:showSendDialog@window->wn-send#show"
                 >
-                    <div class="help-block help-info">
+                    <p class="w-dialog__subtitle w-help-text">
+                        This action will save a draft page revision.
+                    </p>
+
+                    <div class="help-block help-warning">
                         {% icon name="warning" %}
                         <p data-wn-send-target="message"></p>
                     </div>
 
-                    <button type="submit" class="button button-primary">Send</button>
-                    <button type="button" class="button button-secondary" data-action="w-dialog#hide">Cancel</button>
-                </form>
+                    <button
+                        type="submit"
+                        class="button button-primary"
+                        name="newsletter-action"
+                        value="send_campaign"
+                        data-controller="wn-submit"
+                        data-action="
+                            wn-submit#sendEvent
+                            w-dialog#hide
+                        "
+                    >
+                        Send
+                    </button>
+
+                    <button
+                        type="button"
+                        class="button button-secondary"
+                        data-action="w-dialog#hide"
+                    >
+                        Cancel
+                    </button>
+                </div>
             {% enddialog %}
-
-            <button
-                type="submit"
-                class="w-hidden"
-                name="newsletter-action"
-                value="send_test_email"
-                data-wn-panel-target="testSubmit"
-            >
-                Send test email
-            </button>
-
-            <button
-                type="submit"
-                class="w-hidden"
-                name="newsletter-action"
-                value="send_campaign"
-                data-wn-panel-target="sendSubmit"
-            >
-                Send campaign
-            </button>
         </p>
     {% endif %}
 


### PR DESCRIPTION
* Change the dialogs to open inside the page editor form (fixes https://github.com/wagtail/wagtail-newsletter/issues/59).
* Remove the hidden buttons and input fields; the user-visible controls inside the dialogs are now part of the form so we don't need to copy data and forward submit events.
* Because the dialogs live at the end of the `<form>` element, the newsletter buttons are no longer triggered when pressing `<enter>` in a field - fixes https://github.com/wagtail/wagtail-newsletter/issues/58. (TODO pressing `<enter>` in the send-test-email dialog should trigger the button in the dialog)
* Fixes https://github.com/wagtail/wagtail-newsletter/issues/54.
