### PR TITLE
Bump supported versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - run: git clone https://github.com/wagtail/wagtail.git
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Turn Wagtail pages into newsletters.
 
 - Python (3.8, 3.9, 3.10, 3.11, 3.12)
 - Django (4.2, 5.0)
-- Wagtail (5.2, 6.0, 6.1)
+- Wagtail (5.2, 6.1, 6.2)
 
 ## Installation
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.0,6.1}-{sqlite,postgres}
-    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.0,6.1}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -37,8 +37,8 @@ deps =
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.0: wagtail>=6.0,<6.1
     wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
 
     postgres: psycopg2>=2.6
 


### PR DESCRIPTION
Add Wagtail 6.2 and remove 6.0 since it's no longer supported.