### PR TITLE
Update versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         env:
           FLIT_ROOT_INSTALL: true
@@ -42,7 +42,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -64,11 +64,11 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12']
 
     services:
       postgres:
-        image: ${{ matrix.postgres || 'postgres:12' }}
+        image: ${{ matrix.postgres || 'postgres:13' }}
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,7 @@ flit install
 
 ## pre-commit
 
-Note that this project uses [pre-commit](https://github.com/pre-commit/pre-commit).
-It is included in the project testing requirements. To set up locally:
+Note that this project uses [pre-commit](https://github.com/pre-commit/pre-commit).  It is included in the project testing requirements. To set up locally:
 
 ```shell
 # go to the project directory
@@ -48,15 +47,13 @@ Now you can run tests as shown below:
 tox
 ```
 
-or, you can run them for a specific environment `tox -e python3.12-django5.0-wagtail6.1` or specific test
-`tox -e python3.12-django5.0-wagtail6.1-sqlite wagtail-newsletter.tests.test_file.TestClass.test_method`
+or, you can run them for a specific environment `tox -e python3.12-django5.1-wagtail6.3` or specific test `tox -e python3.12-django5.1-wagtail6.3-sqlite -- wagtail-newsletter.tests.test_file.TestClass.test_method`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.
 
 ## How to build the documentation
 
-The documentation source lives under `docs/`. It's built with [Sphinx](https://www.sphinx-doc.org/).
-You can start a development server that will auto-build and refresh the page in the browser:
+The documentation source lives under `docs/`. It's built with [Sphinx](https://www.sphinx-doc.org/).  You can start a development server that will auto-build and refresh the page in the browser:
 
 ```sh
 pip install sphinx-autobuild

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Turn Wagtail pages into newsletters.
 
 ## Supported versions
 
-- Python (3.8, 3.9, 3.10, 3.11, 3.12)
+- Python (3.9, 3.10, 3.11, 3.12)
 - Django (4.2, 5.0)
 - Wagtail (5.2, 6.1, 6.2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -27,7 +26,7 @@ classifiers = [
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "Django>=4.2",
@@ -80,7 +79,7 @@ exclude = [
 ]
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "wagtail_newsletter.test.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ pythonVersion = "3.8"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "wagtail_newsletter.test.settings"
+pythonpath = ["."]
 testpaths = [
     "tests",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
-    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
+    python{3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.2,6.3}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0,5.1}-wagtail{5.2,6.2,6.3}-{sqlite,postgres}
 
 [gh-actions]
 python =
-    3.8: python3.8
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
@@ -20,7 +19,6 @@ DB =
 commands = pytest --cov {posargs: -vv}
 
 basepython =
-    python3.8: python3.8
     python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,4 @@
 [tox]
-skipsdist = True
-usedevelop = True
-
 envlist =
     python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
     python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.1,6.2}-{sqlite,postgres}
@@ -20,7 +17,6 @@ DB =
     postgres: postgres
 
 [testenv]
-install_command = pip install -e ".[testing,mailchimp,mrml]" -U {opts} {packages}
 commands = pytest --cov {posargs: -vv}
 
 basepython =
@@ -41,6 +37,11 @@ deps =
     wagtail6.2: wagtail>=6.2,<6.3
 
     postgres: psycopg2>=2.6
+
+extras =
+    testing
+    mailchimp
+    mrml
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_newsletter}


### PR DESCRIPTION
- Fix `tox` config to work with `tox-uv`
- Drop Python 3.8
- Add Django 5.1
- Drop Wagtail 6.1, add 6.3
- Bump Postgres to version 13 (Django 5.1 requires it)
