### PR TITLE
Upgrade to `mrml` version 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+- Bump minimum `mrml` version to `0.2` (#72).
+
 ## [0.2.1] - 2024-09-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ mailchimp = [
     "mailchimp-marketing>=3.0.80",
 ]
 mrml = [
-    "mrml>=0.1.13",
+    "mrml>=0.2",
 ]
 
 [project.urls]

--- a/wagtail_newsletter/templatetags/wagtail_newsletter.py
+++ b/wagtail_newsletter/templatetags/wagtail_newsletter.py
@@ -32,7 +32,8 @@ class MRMLRenderNode(template.Node):
 
         mjml_source = self.nodelist.render(context)
         try:
-            return mrml.to_html(mjml_source)
+            output = mrml.to_html(mjml_source)
+            return output.content
         except OSError as error:
             # The MRML library raises OSError exceptions when something goes wrong.
             message = error.args[0]


### PR DESCRIPTION
The API of the `mrml` library has changed: `mrml.to_html` now returns an `Output` object instead of a string. The object's `.content` attribute contains the actual output string.

I've also raised a PR with `mrml` to update the documentation: https://github.com/jdrouet/mrml/pull/523.