### PR TITLE
Extract `get_newsletter_subject` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump minimum `mrml` version to `0.2` (#72).
+- Bump minimum `mrml` version to `0.2` (#72)
+- Extract get_newsletter_subject method (#77)
 
 ### Removed
 

--- a/wagtail_newsletter/actions.py
+++ b/wagtail_newsletter/actions.py
@@ -12,7 +12,7 @@ def save_campaign(request, page: NewsletterPageMixin) -> None:
     backend = campaign_backends.get_backend()
     revision = page.latest_revision
     version = cast(NewsletterPageMixin, revision.as_object())
-    subject = version.newsletter_subject or version.title
+    subject = version.get_newsletter_subject()
 
     try:
         campaign_id = backend.save_campaign(

--- a/wagtail_newsletter/models.py
+++ b/wagtail_newsletter/models.py
@@ -162,6 +162,9 @@ class NewsletterPageMixin(Page):
             context=self.get_newsletter_context(),
         )
 
+    def get_newsletter_subject(self) -> str:
+        return self.newsletter_subject or self.title
+
     def serve_preview(self, request, mode_name):  # type: ignore
         if mode_name == "newsletter":
             return HttpResponse(self.get_newsletter_html().encode())


### PR DESCRIPTION
Make it possible to programatically override how the email subject is generated.