### PR TITLE
Fix django51 tox pin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     python{3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.3,6.4}-{sqlite,postgres}
-    python{3.10,3.11,3.12}-django{5.0,5.1}-wagtail{5.2,6.3,6.4}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0,5.1}-wagtail{6.3,6.4}-{sqlite,postgres}
     python{3.13}-django{5.1}-wagtail{6.3,6.4}-{sqlite,postgres}
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
 
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
+    django5.1: Django>=5.1,<5.2
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4


### PR DESCRIPTION
[This CI run](https://github.com/wagtail/wagtail-newsletter/actions/runs/14494831644) failed because Django 5.1 was not pinned in the Tox config and the latest Django (5.2) was being installed instead.