### PR TITLE
`{% newsletter_static %}` template tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump minimum `mrml` version to `0.2` (#72)
 - Extract get_newsletter_subject method (#77)
+- `{% newsletter_static %}` template tag (#79)
 
 ### Removed
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -31,6 +31,21 @@ it into HTML.
 .. _MJML: https://mjml.io
 .. _mrml: https://github.com/jdrouet/mrml
 
+The ``{% newsletter_static %}`` template tag
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``{% newsletter_static %}`` template tag is used to embed static files in
+newsletters. It works like Django's ``{% static %}`` template tag, but it
+generates a fully-qualified URL for the static file, by prepending Wagtail's
+``WAGTAILADMIN_BASE_URL`` setting to the path.
+
+.. code-block:: htmldjango
+
+  {% load wagtail_newsletter %}
+  ...
+
+  {% newsletter_static "images/logo.png" %}
+
 The ``newsletter_richtext`` filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_mrml.py
+++ b/tests/test_mrml.py
@@ -52,3 +52,16 @@ def test_render_mjml_syntax_error():
         template.render(Context())
 
     assert error.match("Failed to render MJML: 'unexpected token")
+
+
+def test_newsletter_static_tag(settings):
+    settings.WAGTAILADMIN_BASE_URL = "http://example.com"
+
+    template = Template(
+        """
+        {% load wagtail_newsletter %}
+        {% newsletter_static 'test/static/file.css' %}
+        """
+    )
+    result = template.render(Context())
+    assert result.strip() == "http://example.com/static/test/static/file.css"

--- a/wagtail_newsletter/templatetags/wagtail_newsletter.py
+++ b/wagtail_newsletter/templatetags/wagtail_newsletter.py
@@ -70,4 +70,4 @@ def newsletter_static(path):
     Variant of the {% static %}` tag for use in newsletter emails - tries to form
     a full URL using WAGTAILADMIN_BASE_URL if the static URL isn't already a full URL.
     """
-    return urljoin(get_admin_base_url(), static(path))
+    return urljoin(get_admin_base_url() or "", static(path))

--- a/wagtail_newsletter/templatetags/wagtail_newsletter.py
+++ b/wagtail_newsletter/templatetags/wagtail_newsletter.py
@@ -1,5 +1,9 @@
+from urllib.parse import urljoin
+
 from django import template
+from django.templatetags.static import static
 from django.utils.safestring import mark_safe
+from wagtail.admin.utils import get_admin_base_url
 from wagtail.rich_text import RichText
 
 from ..rich_text import rewrite_db_html_for_email
@@ -58,3 +62,12 @@ def mrml_tag(parser, token) -> MRMLRenderNode:
             f"{tokens[0]!r} tag doesn't receive any arguments."
         )
     return MRMLRenderNode(nodelist)
+
+
+@register.simple_tag
+def newsletter_static(path):
+    """
+    Variant of the {% static %}` tag for use in newsletter emails - tries to form
+    a full URL using WAGTAILADMIN_BASE_URL if the static URL isn't already a full URL.
+    """
+    return urljoin(get_admin_base_url(), static(path))


### PR DESCRIPTION
Template tag to generate fully-qualified URLs for static files, based on Wagtail's `{% notification_static %}` tag: https://github.com/wagtail/wagtail/blob/v6.4.1/wagtail/admin/templatetags/wagtailadmin_tags.py#L720-L726