### PR TITLE
Validate schedule time before saving to Mailchimp

### DIFF
--- a/wagtail_newsletter/actions.py
+++ b/wagtail_newsletter/actions.py
@@ -98,9 +98,15 @@ def schedule_campaign(request, page: NewsletterPageMixin) -> None:
 
     schedule_time = form.cleaned_data["schedule_time"]
 
-    save_campaign(request, page)
-
     backend = campaign_backends.get_backend()
+
+    try:
+        backend.validate_schedule_time(schedule_time)
+    except campaign_backends.CampaignBackendError as error:
+        messages.error(request, error.message)
+        return
+
+    save_campaign(request, page)
 
     try:
         backend.schedule_campaign(

--- a/wagtail_newsletter/campaign_backends/__init__.py
+++ b/wagtail_newsletter/campaign_backends/__init__.py
@@ -60,6 +60,10 @@ class CampaignBackend(ABC):
     @abstractmethod
     def send_campaign(self, campaign_id: str) -> None: ...
 
+    def validate_schedule_time(self, schedule_time: datetime) -> None:  # noqa: B027
+        """Validate schedule time. Override in subclass if backend has restrictions."""
+        pass
+
     @abstractmethod
     def schedule_campaign(self, campaign_id: str, schedule_time: datetime) -> None: ...
 

--- a/wagtail_newsletter/campaign_backends/mailchimp.py
+++ b/wagtail_newsletter/campaign_backends/mailchimp.py
@@ -253,7 +253,7 @@ class MailchimpCampaignBackend(CampaignBackend):
                 error, "Error while sending campaign", campaign_id=campaign_id
             )
 
-    def schedule_campaign(self, campaign_id: str, schedule_time: datetime) -> None:
+    def validate_schedule_time(self, schedule_time: datetime) -> None:
         rounded_minute = schedule_time.minute - (schedule_time.minute % 15)
         rounded_time = schedule_time.replace(
             minute=rounded_minute, second=0, microsecond=0
@@ -264,6 +264,9 @@ class MailchimpCampaignBackend(CampaignBackend):
                 f" e.g. {schedule_time.hour:02d}:{rounded_minute:02d} "
                 f"not {schedule_time.hour:02d}:{schedule_time.minute:02d}."
             )
+
+    def schedule_campaign(self, campaign_id: str, schedule_time: datetime) -> None:
+        self.validate_schedule_time(schedule_time)
 
         try:
             self.client.campaigns.schedule(


### PR DESCRIPTION
Fix https://github.com/wagtail/wagtail-newsletter/issues/81

We can validate the scheduled time before saving the campaign to Mailchimp. The page itself is still saved though, because all our code runs in an `after_edit_page` hook.

<img width="1382" height="646" alt="Screenshot 2025-07-11 at 16 47 41" src="https://github.com/user-attachments/assets/a6d5f491-0873-4e67-b7ef-0a48be8d4633" />
